### PR TITLE
Allow advertising arbitrary mfg data

### DIFF
--- a/dev.go
+++ b/dev.go
@@ -22,6 +22,9 @@ type Device interface {
 	// If name doesn't fit in the advertising packet, it will be put in scan response.
 	AdvertiseNameAndServices(ctx context.Context, name string, uuids ...UUID) error
 
+	// AdvertiseMfgData avertises the given manufacturer data.
+	AdvertiseMfgData(ctx context.Context, id uint16, b []byte) error
+
 	// AdvertiseIBeaconData advertise iBeacon with given manufacturer data.
 	AdvertiseIBeaconData(ctx context.Context, b []byte) error
 

--- a/linux/device.go
+++ b/linux/device.go
@@ -98,6 +98,16 @@ func (d *Device) AdvertiseNameAndServices(ctx context.Context, name string, uuid
 	return ctx.Err()
 }
 
+// AdvertiseMfgData avertises the given manufacturer data.
+func (d *Device) AdvertiseMfgData(ctx context.Context, id uint16, b []byte) error {
+	if err := d.HCI.AdvertiseMfgData(id, b); err != nil {
+		return err
+	}
+	<-ctx.Done()
+	d.HCI.StopAdvertising()
+	return ctx.Err()
+}
+
 // AdvertiseIBeaconData advertise iBeacon with given manufacturer data.
 func (d *Device) AdvertiseIBeaconData(ctx context.Context, b []byte) error {
 	if err := d.HCI.AdvertiseIBeaconData(b); err != nil {

--- a/linux/hci/gap.go
+++ b/linux/hci/gap.go
@@ -78,6 +78,18 @@ func (h *HCI) AdvertiseNameAndServices(name string, uuids ...ble.UUID) error {
 	return h.Advertise()
 }
 
+// AdvertiseMfgData avertises the given manufacturer data.
+func (h *HCI) AdvertiseMfgData(id uint16, md []byte) error {
+	ad, err := adv.NewPacket(adv.ManufacturerData(id, md))
+	if err != nil {
+		return err
+	}
+	if err := h.SetAdvertisement(ad.Bytes(), nil); err != nil {
+		return nil
+	}
+	return h.Advertise()
+}
+
 // AdvertiseIBeaconData advertise iBeacon with given manufacturer data.
 func (h *HCI) AdvertiseIBeaconData(md []byte) error {
 	ad, err := adv.NewPacket(adv.IBeaconData(md))


### PR DESCRIPTION
This allows advertising arbitrary manufacturer data on both darwin and linux by adding `AdvertiseMfgData()` to the `bleDevice` interface.

In order to make this work and be consistent, I had to change `darwin.AdvertiseMfgData()` to take a manufacturer id as a parameter.  It was only used internally by the `darwin.AdvertiseIBeaconData()` function, which was prepending the ibeacon data with the manufacturer id before passing it to `AdvertiseMfgData()`.  Other than changing this one exported function which I doubt many developers are using directly, there should be no other breaking changes.