### PR TITLE
Adds an AdvertiseServiceData16 function to the device interface

### DIFF
--- a/darwin/device.go
+++ b/darwin/device.go
@@ -131,6 +131,22 @@ func (d *Device) AdvertiseMfgData(ctx context.Context, id uint16, md []byte) err
 	return ctx.Err()
 }
 
+// AdvertiseServiceData16 advertises data associated with a 16bit service uuid
+func (d *Device) AdvertiseServiceData16(ctx context.Context, id uint16, b []byte) error {
+	l := len(b)
+	prefix := []byte{
+		0x03, 0x03, uint8(id), uint8(id >> 8),
+		byte(l + 3), 0x16, uint8(id), uint8(id >> 8),
+	}
+	if err := d.sendReq(d.pm, 8, xpc.Dict{
+		"kCBAdvDataAppleMfgData": append(prefix, b...),
+	}).err(); err != nil {
+		return errors.Wrap(err, "can't advertise")
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+
 // AdvertiseNameAndServices advertises name and specifid service UUIDs.
 func (d *Device) AdvertiseNameAndServices(ctx context.Context, name string, ss ...ble.UUID) error {
 	if err := d.sendReq(d.pm, 8, xpc.Dict{

--- a/dev.go
+++ b/dev.go
@@ -25,6 +25,9 @@ type Device interface {
 	// AdvertiseMfgData avertises the given manufacturer data.
 	AdvertiseMfgData(ctx context.Context, id uint16, b []byte) error
 
+	// AdvertiseServiceData16 advertises data associated with a 16bit service uuid
+	AdvertiseServiceData16(ctx context.Context, id uint16, b []byte) error
+
 	// AdvertiseIBeaconData advertise iBeacon with given manufacturer data.
 	AdvertiseIBeaconData(ctx context.Context, b []byte) error
 

--- a/linux/adv/packet.go
+++ b/linux/adv/packet.go
@@ -91,7 +91,7 @@ func IBeacon(u ble.UUID, major, minor uint16, pwr int8) Field {
 		md := make([]byte, 23)
 		md[0] = 0x02                               // Data type: iBeacon
 		md[1] = 0x15                               // Data length: 21 bytes
-		copy(md[2:], ble.Reverse(u))                // Big endian
+		copy(md[2:], ble.Reverse(u))               // Big endian
 		binary.BigEndian.PutUint16(md[18:], major) // Big endian
 		binary.BigEndian.PutUint16(md[20:], minor) // Big endian
 		md[22] = uint8(pwr)                        // Measured Tx Power
@@ -151,6 +151,17 @@ func SomeUUID(u ble.UUID) Field {
 			return p.append(someUUID32, u)
 		}
 		return p.append(someUUID128, u)
+	}
+}
+
+// ServiceData16 is service data for a 16bit service uuid
+func ServiceData16(id uint16, b []byte) Field {
+	return func(p *Packet) error {
+		uuid := ble.UUID16(id)
+		if err := p.append(allUUID16, uuid); err != nil {
+			return err
+		}
+		return p.append(serviceData16, append(uuid, b...))
 	}
 }
 

--- a/linux/device.go
+++ b/linux/device.go
@@ -108,6 +108,16 @@ func (d *Device) AdvertiseMfgData(ctx context.Context, id uint16, b []byte) erro
 	return ctx.Err()
 }
 
+// AdvertiseServiceData16 advertises data associated with a 16bit service uuid
+func (d *Device) AdvertiseServiceData16(ctx context.Context, id uint16, b []byte) error {
+	if err := d.HCI.AdvertiseServiceData16(id, b); err != nil {
+		return err
+	}
+	<-ctx.Done()
+	d.HCI.StopAdvertising()
+	return ctx.Err()
+}
+
 // AdvertiseIBeaconData advertise iBeacon with given manufacturer data.
 func (d *Device) AdvertiseIBeaconData(ctx context.Context, b []byte) error {
 	if err := d.HCI.AdvertiseIBeaconData(b); err != nil {

--- a/linux/hci/gap.go
+++ b/linux/hci/gap.go
@@ -90,6 +90,18 @@ func (h *HCI) AdvertiseMfgData(id uint16, md []byte) error {
 	return h.Advertise()
 }
 
+// AdvertiseServiceData16 advertises data associated with a 16bit service uuid
+func (h *HCI) AdvertiseServiceData16(id uint16, b []byte) error {
+	ad, err := adv.NewPacket(adv.ServiceData16(id, b))
+	if err != nil {
+		return err
+	}
+	if err := h.SetAdvertisement(ad.Bytes(), nil); err != nil {
+		return nil
+	}
+	return h.Advertise()
+}
+
 // AdvertiseIBeaconData advertise iBeacon with given manufacturer data.
 func (h *HCI) AdvertiseIBeaconData(md []byte) error {
 	ad, err := adv.NewPacket(adv.IBeaconData(md))


### PR DESCRIPTION
This allows advertising service data for 16bit service uuids. Google's Eddystone standard is an example of one place where you might want to use this.

Here's an example of how you'd advertise as an Eddystone UID beacon:
```go
eddystoneUuid := 0xfeaa
uid := []byte{
	0x00,                                                       //frame type
	0xeb,                                                       // calibrated pwr
	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // namespace
	0x00, 0x00, 0x00, 0x00, 0x00, 0x01,                         // instance
	0x00, 0x00,                                                 // reserved for future use
}
device.AdvertiseServiceData16(ctx, eddystoneUuid, uid)
```