### PR TITLE
Correct #11 by reseting the hci device during initialization

### DIFF
--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -175,6 +175,8 @@ func (h *HCI) Option(opts ...Option) error {
 }
 
 func (h *HCI) init() error {
+	h.Send(&cmd.Reset{}, nil)
+
 	ReadBDADDRRP := cmd.ReadBDADDRRP{}
 	h.Send(&cmd.ReadBDADDR{}, &ReadBDADDRRP)
 


### PR DESCRIPTION
This PR corrects #11 which is a simple fix for stubborn Linux HCI devices, by simply reseting them during the ble initialization process.