### PR TITLE
Fix Stop() call in linux/device

### DIFF
--- a/gatt.go
+++ b/gatt.go
@@ -50,7 +50,7 @@ func Stop() error {
 	if defaultDevice == nil {
 		return ErrDefaultDevice
 	}
-	return nil
+	return defaultDevice.Stop()
 }
 
 // AdvertiseNameAndServices advertises device name, and specified service UUIDs.

--- a/linux/device.go
+++ b/linux/device.go
@@ -83,7 +83,7 @@ func (d *Device) SetServices(svcs []*ble.Service) error {
 
 // Stop stops gatt server.
 func (d *Device) Stop() error {
-	return d.HCI.Close()
+	return d.HCI.Stop()
 }
 
 // AdvertiseNameAndServices advertises device name, and specified service UUIDs.

--- a/linux/device.go
+++ b/linux/device.go
@@ -83,7 +83,7 @@ func (d *Device) SetServices(svcs []*ble.Service) error {
 
 // Stop stops gatt server.
 func (d *Device) Stop() error {
-	return d.HCI.Stop()
+	return d.HCI.Close()
 }
 
 // AdvertiseNameAndServices advertises device name, and specified service UUIDs.

--- a/linux/hci/gap.go
+++ b/linux/hci/gap.go
@@ -187,14 +187,6 @@ func (h *HCI) Dial(ctx context.Context, a ble.Addr) (ble.Client, error) {
 	}
 }
 
-// Close ...
-func (h *HCI) Close() error {
-	if h.err != nil {
-		return h.err
-	}
-	return nil
-}
-
 // Advertise starts advertising.
 func (h *HCI) Advertise() error {
 	h.params.advEnable.AdvertisingEnable = 1

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -155,9 +155,9 @@ func (h *HCI) Init() error {
 	return nil
 }
 
-// Stop ...
-func (h *HCI) Stop() error {
-	return h.stop(nil)
+// Close ...
+func (h *HCI) Close() error {
+	return h.close(nil)
 }
 
 // Error ...
@@ -242,14 +242,14 @@ func (h *HCI) send(c Command) ([]byte, error) {
 	b[2] = byte(c.OpCode() >> 8)
 	b[3] = byte(c.Len())
 	if err := c.Marshal(b[4:]); err != nil {
-		h.stop(fmt.Errorf("hci: failed to marshal cmd"))
+		h.close(fmt.Errorf("hci: failed to marshal cmd"))
 	}
 
 	h.sent[c.OpCode()] = p // TODO: lock
 	if n, err := h.skt.Write(b[:4+c.Len()]); err != nil {
-		h.stop(fmt.Errorf("hci: failed to send cmd"))
+		h.close(fmt.Errorf("hci: failed to send cmd"))
 	} else if n != 4+c.Len() {
-		h.stop(fmt.Errorf("hci: failed to send whole cmd pkt to hci socket"))
+		h.close(fmt.Errorf("hci: failed to send whole cmd pkt to hci socket"))
 	}
 
 	select {
@@ -278,7 +278,7 @@ func (h *HCI) sktLoop() {
 	}
 }
 
-func (h *HCI) stop(err error) error {
+func (h *HCI) close(err error) error {
 	h.err = err
 	return h.skt.Close()
 }


### PR DESCRIPTION
The default Stop() did nothing before (just returned `nil`).
`HCI.Close()` also just returns `nil`.

I therefore change it to `HCI.Stop()`

Should there be a difference in behavior between `HCI.Close()` and `HCI.Stop()` or is `HCI.Close()` obsolete?
