### PR TITLE
Use correct ID for OS X message when writing BLE characteristic with response

### DIFF
--- a/darwin/client.go
+++ b/darwin/client.go
@@ -179,7 +179,7 @@ func (cln *Client) WriteCharacteristic(c *ble.Characteristic, b []byte, noRsp bo
 		cln.conn.sendCmd(66, args)
 		return nil
 	}
-	return cln.conn.sendReq(65, args).err()
+	return cln.conn.sendReq(66, args).err()
 }
 
 // ReadDescriptor reads a characteristic descriptor from a server. [Vol 3, Part G, 4.12.1]


### PR DESCRIPTION
When using the OS X XPC API to write a BLE characteristic, you must use the ID `66` in both cases: when expecting a response, and also without response. This PR corrects that problem.