### PR TITLE
Add client ReadLongCharacteristic for Linux

### DIFF
--- a/linux/gatt/README.md
+++ b/linux/gatt/README.md
@@ -24,7 +24,7 @@ This package implement Generic Attribute Profile (GATT) [Vol 3, Part G]
 #### Characteristic Value Read [4.8]
   - [ ] Read Characteristic Value [4.8.1]
   - [ ] Read Using Characteristic UUID [4.8.2]
-  - [ ] Read Long Characteristic Values [4.8.3]
+  - [x] Read Long Characteristic Values [4.8.3]
   - [ ] Read Multiple Characteristic Values [4.8.4]
 
 #### Characteristic Value Write [4.9]

--- a/linux/gatt/client.go
+++ b/linux/gatt/client.go
@@ -212,24 +212,24 @@ func (p *Client) ReadCharacteristic(c *ble.Characteristic) ([]byte, error) {
 }
 
 // ReadLongCharacteristic reads a characteristic value which is longer than the MTU. [Vol 3, Part G, 4.8.3]
-func (p *Client) ReadLongCharacteristic(c *ble.Characteristic) ([]byte,error) {
+func (p *Client) ReadLongCharacteristic(c *ble.Characteristic) ([]byte, error) {
 	p.Lock()
 	defer p.Unlock()
 
 	// The maximum length of an attribute value shall be 512 octects [Vol 3, 3.2.9]
-	buffer := make([]byte,0,512)
+	buffer := make([]byte, 0, 512)
 
 	read, err := p.ac.Read(c.ValueHandle)
 	if err != nil {
 		return nil, err
 	}
-	buffer = append(buffer,read...)
+	buffer = append(buffer, read...)
 
 	for len(read) >= p.conn.TxMTU()-1 {
-		if read, err = p.ac.ReadBlob(c.ValueHandle,uint16(len(buffer))); err != nil {
-                        return nil, err
-                }
-		buffer = append(buffer,read...)
+		if read, err = p.ac.ReadBlob(c.ValueHandle, uint16(len(buffer))); err != nil {
+			return nil, err
+		}
+		buffer = append(buffer, read...)
 	}
 	return buffer, nil
 }


### PR DESCRIPTION
Implemented readlongcharacteristic in linux/gatt/client.go for reading characteristic values larger than the MTU.