### PR TITLE
Avoid deref cln if nil

### DIFF
--- a/examples/blesh/main.go
+++ b/examples/blesh/main.go
@@ -256,13 +256,13 @@ func cmdConnect(c *cli.Context) error {
 	if err == nil {
 		curr.client = cln
 		curr.clients[cln.Address().String()] = cln
+		go func() {
+			<-cln.Disconnected()
+			delete(curr.clients, cln.Address().String())
+			curr.client = nil
+			fmt.Printf("\n%s disconnected\n", cln.Address().String())
+		}()
 	}
-	go func() {
-		<-cln.Disconnected()
-		delete(curr.clients, cln.Address().String())
-		curr.client = nil
-		fmt.Printf("\n%s disconnected\n", cln.Address().String())
-	}()
 	return err
 }
 


### PR DESCRIPTION
Fixes this error: 

```
blesh > c -name _<name>_
Scanning with filter...
blesh > panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x41a89b6]

goroutine 70 [running]:
main.cmdConnect.func1(0x0, 0x0)
        /Users/liz/go/src/github.com/currantlabs/ble/examples/blesh/main.go:261 +0x26
created by main.cmdConnect
        /Users/liz/go/src/github.com/currantlabs/ble/examples/blesh/main.go:260 +0x266
```