### PR TITLE
allow using handles to read and write, fix write

### DIFF
--- a/examples/blesh/flg.go
+++ b/examples/blesh/flg.go
@@ -13,5 +13,7 @@ var (
 	flgSvc      = cli.StringFlag{Name: "svc, s", Usage: "Services of remote device"}
 	flgAllowDup = cli.BoolFlag{Name: "dup", Usage: "Allow duplicate in scanning result"}
 	flgUUID     = cli.StringFlag{Name: "uuid, u", Usage: "UUID"}
+	flgHandle   = cli.StringFlag{Name: "handle, hd", Usage: "Item handle"}
+	flgVal      = cli.StringFlag{Name: "value, v", Usage: "Item value"}
 	flgInd      = cli.BoolFlag{Name: "ind", Usage: "Indication"}
 )

--- a/examples/blesh/util.go
+++ b/examples/blesh/util.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/currantlabs/ble"
 	"github.com/pkg/errors"
@@ -19,6 +20,44 @@ func doGetUUID(c *cli.Context) error {
 	}
 	if curr.uuid == nil {
 		return errNoUUID
+	}
+	return nil
+}
+
+func doGetHandle(c *cli.Context) error {
+	// The UUID always has priority. If already non-nil, exit
+	if curr.uuid != nil {
+		return nil
+	}
+	handleRetrieved := false
+	if c.String("handle") != "" {
+		hStr := c.String("handle")
+		if len(hStr) > 2 && hStr[0] == '0' && (hStr[1] == 'x' || hStr[1] == 'X') {
+			hStr = hStr[2:]
+		}
+		h, err := strconv.ParseUint(hStr, 16, 16)
+		if err != nil {
+			return errInvalidHandle
+		}
+		curr.handle = uint16(h)
+		handleRetrieved = true
+	}
+	// Since uuid takes priority, unlike doGetUUID, we avoid handling
+	// any "no handle provided" scenarios, and return errNoUUID as well
+	if !handleRetrieved {
+		return errNoUUID
+	}
+
+	return nil
+}
+
+func doGetVal(c *cli.Context) error {
+	if c.String("value") != "" {
+		val := c.String("value")
+		curr.val = &val
+	}
+	if curr.val == nil {
+		return errNoVal
 	}
 	return nil
 }

--- a/profile.go
+++ b/profile.go
@@ -67,6 +67,38 @@ func (p *Profile) Find(target interface{}) interface{} {
 	return nil
 }
 
+// FindByHandle searches discovered profile for the specified target's type and handle.
+// The target must has the type of *Service, *Characteristic, or *Descriptor.
+func (p *Profile) FindByHandle(target interface{}) interface{} {
+	switch target.(type) {
+	case *Service:
+	case *Characteristic:
+	case *Descriptor:
+	default:
+		return nil
+	}
+	for _, s := range p.Services {
+		ts, ok := target.(*Service)
+		if ok && s.Handle == ts.Handle {
+			target = s
+			return s
+		}
+		for _, c := range s.Characteristics {
+			tc, ok := target.(*Characteristic)
+			if ok && c.Handle == tc.Handle {
+				return c
+			}
+			for _, d := range c.Descriptors {
+				td, ok := target.(*Descriptor)
+				if ok && d.Handle == td.Handle {
+					return d
+				}
+			}
+		}
+	}
+	return nil
+}
+
 // A Service is a BLE service.
 type Service struct {
 	UUID            UUID


### PR DESCRIPTION
This pull request 

a) adds the ability to find a descriptor or characteristic by handle, not just by uuid (profile.go -> FindByHandle)

b) Improves the blesh tool, fixing the write, as well as read / writes by handle.
Using interactive shell:
```
 r --addr 00:15:83:EC:E1:05 --uuid 0000b0031e3dfad474e297a033f1bfee
 r --addr 00:15:83:EC:E1:05 --uuid 2901
 r --addr 00:15:83:EC:E1:05 --handle 0x131

 w --addr 00:15:83:EC:E1:05 --handle 0x131 --value="Ypeee"
```
or directly from the OS shell:
```
sudo ./blesh w --addr 00:15:83:EC:E1:05 --handle 0x131 --value="Ypeee3"
sudo ./blesh w --addr 00:15:83:EC:E1:05 --uuid 000000021e3cfad474e297a033f1bfaa --value="howdy"
```
