### PR TITLE
ble/darwin: fixes OSX unsupported key for MTU

### DIFF
--- a/darwin/msg.go
+++ b/darwin/msg.go
@@ -12,7 +12,12 @@ func (m msg) args() xpc.Dict { return xpc.Dict(m).MustGetDict("kCBMsgArgs") }
 func (m msg) advertisementData() xpc.Dict {
 	return xpc.Dict(m).MustGetDict("kCBMsgArgAdvertisementData")
 }
-func (m msg) attMTU() int          { return xpc.Dict(m).MustGetInt("kCBMsgArgATTMTU") }
+
+const macOSXDefaultMTU = 23
+
+// Uses GetInt as oppose to MustGetInt due to OSX not supporting 'kCBMsgArgATTMTU'.
+// Issue #70
+func (m msg) attMTU() int          { return xpc.Dict(m).GetInt("kCBMsgArgATTMTU", macOSXDefaultMTU) }
 func (m msg) attWrites() xpc.Array { return xpc.Dict(m).MustGetArray("kCBMsgArgATTWrites") }
 func (m msg) attributeID() int     { return xpc.Dict(m).MustGetInt("kCBMsgArgAttributeID") }
 func (m msg) characteristicHandle() int {


### PR DESCRIPTION
Due to `OSX` not supporting key, `kCBMsgArgATTMTU`, this changes use of `MustGetInt` to `GetInt` with a default of 23 MTU unless `kCBMsgArgATTMTU` is present.

Fixes #70 